### PR TITLE
Topic/unified stdout stderr json

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lcmap-cli "0.1.3"
+(defproject lcmap-cli "0.1.4"
   :description "LCMAP Devops Interface"
   :url "https://github.com/usgs-eros/lcmap-cli"
   :license {:name "Unlicense"

--- a/src/lcmap_cli/changedetection.clj
+++ b/src/lcmap_cli/changedetection.clj
@@ -10,7 +10,7 @@
   [{:keys [:response :cx :cy :grid :acquired]}]
 
   (let [r (try {:response @response}
-               (catch Exception e {:error (-> e st/print-stack-trace with-out-str)}))]
+               (catch Exception e {:error (str e)}))]
     
     (cond (:error r)
           {:cx cx :cy cy :acquired acquired :error (:error r)}
@@ -18,7 +18,7 @@
           (contains? (set (range 200 300))(get-in r [:response :status]))
           (-> (:response r) http/decode :body)
           
-          :else {:cx cx :cy cy :acquired acquired :error r})))
+          :else {:cx cx :cy cy :acquired acquired :error (str r)})))
 
 (defn start-consumers
   [number in-chan out-chan]

--- a/src/lcmap_cli/changedetection.clj
+++ b/src/lcmap_cli/changedetection.clj
@@ -1,5 +1,6 @@
 (ns lcmap-cli.changedetection
   (:require [clojure.core.async :as async]
+            [clojure.stacktrace :as st]
             [lcmap-cli.config :as cfg]
             [lcmap-cli.functions :as f]
             [lcmap-cli.http :as http]
@@ -9,7 +10,7 @@
   [{:keys [:response :cx :cy :grid :acquired]}]
 
   (let [r (try {:response @response}
-               (catch Exception e {:error e}))]
+               (catch Exception e {:error (-> e st/print-stack-trace with-out-str)}))]
     
     (cond (:error r)
           {:cx cx :cy cy :acquired acquired :error (:error r)}
@@ -44,11 +45,9 @@
                                    :acquired a
                                    :grid g})))
     (dotimes [i (count xys)]
-      (let [result (async/<!! out-chan)]
-        (if (:error result)
-          (f/stderr (f/to-json-or-str result))
-          (f/stdout (f/to-json-or-str (or result "no response")))))))
-  all)
+      (f/output (async/<!! out-chan))))
+  
+    all)
       
   
 (defn chip

--- a/src/lcmap_cli/core.clj
+++ b/src/lcmap_cli/core.clj
@@ -118,14 +118,6 @@
   (.addShutdownHook (java.lang.Runtime/getRuntime)
                     (Thread. #(state/shutdown) "shutdown-handler")))
 
-(defn invoke
-  [func opts]
-  (try
-    (func opts)
-    (catch Exception e
-      (-> e st/print-stack-trace with-out-str))))
-
-
 (defn -main [& args]
   (let [{:keys [action options exit-message ok?]} (validate-args args)]
     

--- a/src/lcmap_cli/core.clj
+++ b/src/lcmap_cli/core.clj
@@ -118,6 +118,14 @@
   (.addShutdownHook (java.lang.Runtime/getRuntime)
                     (Thread. #(state/shutdown) "shutdown-handler")))
 
+(defn invoke
+  [func opts]
+  (try
+    (func opts)
+    (catch Exception e
+      (-> e st/print-stack-trace with-out-str))))
+
+
 (defn -main [& args]
   (let [{:keys [action options exit-message ok?]} (validate-args args)]
     
@@ -132,6 +140,7 @@
     ;; string where it occurred.
     ;;
     ;; Simple way to do this is with clojure.stacktrace/print-stack-trace and with-out-str.
+    ;; Alternatively, just make sure you do this: (str (Exception. "an exception"))
     ;;
     ;; Example:  (-> (Exception. "an exception") stacktrace/print-stack-trace with-out-str)
     ;;
@@ -150,7 +159,12 @@
     ;;                          :cy 456
     ;;                          :error (-> e print-stack-trace with-out-str)}))
     ;;
+    ;; (try (something-throws-an-exception)
+    ;;      (catch Exception e {:cx 123
+    ;;                          :cy 456
+    ;;                          :error (str e)}))
+    ;;
     
     (if exit-message
       (exit (if ok? 0 1) exit-message)
-      (f/output ((function action) options)))))      
+      (f/output ((function action) options)))))

--- a/src/lcmap_cli/core.clj
+++ b/src/lcmap_cli/core.clj
@@ -1,6 +1,5 @@
 (ns lcmap-cli.core
   (:require [cheshire.core :as json]
-            [clojure.stacktrace :as st]
             [clojure.string :as string]
             [clojure.tools.cli :refer [parse-opts]]
             [clojure.walk :refer [stringify-keys keywordize-keys]]

--- a/src/lcmap_cli/core.clj
+++ b/src/lcmap_cli/core.clj
@@ -110,10 +110,7 @@
       {:exit-message (usage (-> args first) summary)})))
 
 (defn exit [status msg]
-  (if (not (= 0 status))
-    (f/output {:error (try (-> msg st/print-stack-trace with-out-str)
-                           (catch Exception e e))})
-    (f/output msg))
+  (f/stdout msg)
   (System/exit status))
 
 (defn add-shutdown-hook

--- a/src/lcmap_cli/functions.clj
+++ b/src/lcmap_cli/functions.clj
@@ -14,20 +14,23 @@
   [msg]
   (json/encode (stringify-keys msg)))
 
-(defn to-json-or-str
-  [msg]
-  (try (to-json msg)
-       (catch Exception e
-         (str msg))))
-
 (defn stdout
   [msg]
-  (println msg))
+  (println msg)
+  msg)
 
 (defn stderr
   [msg]
   (binding [*out* *err*]
-    (println msg)))
+    (println msg))
+  msg)
+
+(defn output
+  [result]
+  (if (:error result)
+    (-> result to-json stderr)
+    (-> result to-json stdout))
+  result)
 
 (defn trim
   [v]

--- a/test/lcmap_cli/changedetection_test.clj
+++ b/test/lcmap_cli/changedetection_test.clj
@@ -15,6 +15,7 @@
                                       :headers {:content-type "application/json"}
                                       :body "[\"some-value\"]"})})
            ["some-value"])))
+  
   (testing "(handler) with HTTP 500"
     (is (= (handler {:cx 0
                      :cy 0
@@ -23,9 +24,10 @@
                      :response (atom {:status 500
                                       :headers {:content-type "application/json"}
                                       :body "[\"some-value\"]"})})
-           {:cx 0 :cy 0 :acquired "1980/2019" :error {:response {:status 500
-                                                                 :headers {:content-type "application/json"}
-                                                                 :body "[\"some-value\"]"}}})))
+           {:cx 0
+            :cy 0
+            :acquired "1980/2019"
+            :error "{:response {:status 500, :headers {:content-type \"application/json\"}, :body \"[\\\"some-value\\\"]\"}}"})))
 
   (testing "(handler) with HTTP 200 but decode failure"
     (every? #{:cx :cy :grid :acquired :error}

--- a/test/lcmap_cli/functions_test.clj
+++ b/test/lcmap_cli/functions_test.clj
@@ -41,43 +41,31 @@
     (is (thrown? com.fasterxml.jackson.core.JsonGenerationException
                  (to-json (new java.lang.Object))))))
 
+(deftest stdout-test
+  (testing "testing stdout"
+    (is (= 1 (stdout 1)))
+    (is (= "test" (stdout "test")))
+    (is (true? (stdout true)))
+    (is (false? (stdout false)))
+    (is (= {:a 1} (stdout {:a 1})))))
 
-(deftest to-json-or-str-test
+(deftest stderr-test
+  (testing "testing stderr"
+    (is (= 1 (stderr 1)))
+    (is (= "test" (stderr "test")))
+    (is (true? (stderr true)))
+    (is (false? (stderr false)))
+    (is (= {:a 1} (stderr {:a 1})))))
 
-  (testing "(to-json-or-str Hashmap)"
-    (is (= "{\"key\":\"value\"}" (to-json-or-str {:key "value"}))))
-
-  (testing "(to-json-or-str Integer)"
-    (is (= "1" (to-json-or-str 1))))
-
-  (testing "(to-json-or-str Float)"
-    (is (= "1.0" (to-json-or-str 1.0))))
-
-  (testing "(to-json-or-str Boolean)"
-    (is (= "true" (to-json-or-str true))))
-
-  (testing "(to-json-or-str Vector)"
-    (is (= "[1,2,3]" (to-json-or-str [1 2 3]))))
-
-  (testing "(to-json-or-str List)"
-    (is (= "[1,2,3]" (to-json-or-str '(1 2 3)))))
-
-  (testing "(to-json-or-str Set)"
-    (is (= "[1,3,2]" (to-json-or-str #{1 2 3}))))
-  
-  (testing "(to-json-or-str String)"
-    (is (= "\"a-value\"" (to-json-or-str "a-value"))))
-
-  (testing "(to-json-or-str Keyword)"
-    (is (= "\"a-keyword\"" (to-json-or-str :a-keyword))))
-
-  (testing "(to-json-or-str Rational)"
-    (is (= "0.3333333333333333" (to-json-or-str (/ 1 3)))))
-  
-  (testing "(to-json-or-str Exception)"
-    (is (not (nil? (to-json-or-str (new java.lang.Object)))))
-    (is (= java.lang.String (type (to-json-or-str (new java.lang.Object)))))))
-
+(deftest output-test
+  (testing "testing output"
+    (is (= 1 (output 1)))
+    (is (= "test" (output "test")))
+    (is (true? (output true)))
+    (is (false? (output false)))
+    (is (= {:a 1} (output {:a 1})))
+    (is (thrown? com.fasterxml.jackson.core.JsonGenerationException
+                 (output (Exception. "exceptions aren't json encodable"))))))
 
 (deftest trim-test
 
@@ -89,7 +77,6 @@
   (testing "(trim not-a-string)"
     (is (= 1 (trim 1)))))
 
-
 (deftest transform-matrix-test
 
   (testing "(transform-matrix Hashmap)"
@@ -97,13 +84,11 @@
       (is (= [[3 0 2][0 3 2][0 0 1.0]]
              (transform-matrix gs))))))
 
-
 (deftest point-matrix-test
 
   (testing "(point-matrix Hashmap)"
     (let [p {:x "1" :y "3"}]
       (is (= [[1] [3] [1]] (point-matrix p))))))
-
 
 (deftest tile-to-projection-test
 
@@ -172,7 +157,6 @@
               :tx 2565585.0
               :ty 3314805.0})))))
 
-
 (deftest chip-grid-test
 
   (testing "(chip-grid Hashmap)"
@@ -203,7 +187,6 @@
               :tx 2565585.0
               :ty 3314805.0})))))
 
-
 (deftest lstrip0-test
 
   (testing "(lstrip0 java.lang.String)"
@@ -212,14 +195,12 @@
     (is (= (lstrip0 "00 007") " 007"))
     (is (= (lstrip0 "7") "7"))))
 
-
 (deftest string-to-tile-test
 
   (testing "(string-to-tile java.lang.String)"
     (is (= {:h 0 :v 0} (string-to-tile "000000")))
     (is (= {:h 4 :v 5} (string-to-tile "004005")))
     (is (= {:h 12 :v 7} (string-to-tile "012007")))))
-
 
 (deftest tile-to-string-test
 
@@ -228,14 +209,12 @@
     (is (= "005007" (tile-to-string 5 7)))
     (is (= "111222" (tile-to-string 111 222)))))
 
-
 (deftest xy-to-tile-test
 
   (testing "(xy-to-tile Hashmap)"
     (with-fake-http ["http://fake/grid/snap" "{\"tile\": {\"grid-pt\": [1,2]}}"]
       (is (= (xy-to-tile {:grid "fake-http" :dataset "ard" :x 123 :y 456})
              "001002")))))
-
 
 (deftest tile-to-xy-test
 
@@ -258,7 +237,6 @@
                                            \"ty\": 3314805.0}]]"]
       (is (= (tile-to-xy {:grid "fake-http" :dataset "ard" :tile "001001"})
              {:x -2415585.0 :y 3164805.0})))))
-
 
 (deftest chips-test
   (testing "(chips Hashmap)"
@@ -283,7 +261,6 @@
                         {:cx 15.0 :cy -10.0}
                         {:cx 10.0 :cy -15.0}
                         {:cx 15.0 :cy -15.0}]))))))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;


### PR DESCRIPTION
This change collapses output to lcmap-cli.function/output.

If something that isn't JSON encodable is sent an exception will be raised and the CLI/JVM will stop.  All functions must perform proper error handling.