### PR TITLE
add product-chip option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 *~
+*.tif
+*.xml
+*.txt

--- a/README.md
+++ b/README.md
@@ -18,24 +18,25 @@ Command line interface for the LCMAP system
 
 ## Commands
 
-| Command                      | Required Parameters              | Optional Parameters  | Description                     |
-| ---------------------------- | -------------------------------- |--------------------- | ------------------------------- |
-| lcmap grids                  |                                  |                      | list configured grids           |
-| lcmap grid                   | --grid --dataset                 |                      | show grid configuration         |
-| lcmap snap                   | --grid --dataset --x --y         |                      | snap point to tile/chip         |
-| lcmap near                   | --grid --dataset --x --y         |                      | tile/chip xys near point        |
-| lcmap tile-to-xy             | --grid --dataset --tile          |                      | look up a tile xy from id       |
-| lcmap xy-to-tile             | --grid --dataset --x --y         |                      | look up a tile id from xy       | 
-| lcmap chips                  | --grid --dataset --tile          |                      | list chip xys for tile          |
-| lcmap ingest                 | --grid --dataset --source        |                      | ingest a layer                  |
-| lcmap ingest-list-available  | --grid --dataset --tile          | --start --end        | list ingestable layers          |
-| lcmap ingest-list-completed  | --grid --dataset --tile          | --start --end        | list ingested layers            |
-| lcmap detect                 | --grid --tile --acquired         |                      | detect changes for a tile       |
-| lcmap detect-chip            | --grid --cx --cy --acquired      |                      | detect changes for a chip       |
-| lcmap train                  | --grid --tile                    |                      | train a model for a tile        |
-| lcmap predict                | --grid --tile                    |                      | predict a tile                  |
-| lcmap product                | --grid --tile --product --years  |                      | generate chip size json products|
-| lcmap raster                 | --grid --tile --product --years  |                      | generate tile size map tiff     |
+| Command                      | Required Parameters                | Optional Parameters  | Description                     |
+| ---------------------------- | ---------------------------------- |--------------------- | ------------------------------- |
+| lcmap grids                  |                                    |                      | list configured grids           |
+| lcmap grid                   | --grid --dataset                   |                      | show grid configuration         |
+| lcmap snap                   | --grid --dataset --x --y           |                      | snap point to tile/chip         |
+| lcmap near                   | --grid --dataset --x --y           |                      | tile/chip xys near point        |
+| lcmap tile-to-xy             | --grid --dataset --tile            |                      | look up a tile xy from id       |
+| lcmap xy-to-tile             | --grid --dataset --x --y           |                      | look up a tile id from xy       | 
+| lcmap chips                  | --grid --dataset --tile            |                      | list chip xys for tile          |
+| lcmap ingest                 | --grid --dataset --source          |                      | ingest a layer                  |
+| lcmap ingest-list-available  | --grid --dataset --tile            | --start --end        | list ingestable layers          |
+| lcmap ingest-list-completed  | --grid --dataset --tile            | --start --end        | list ingested layers            |
+| lcmap detect                 | --grid --tile --acquired           |                      | detect changes for a tile       |
+| lcmap detect-chip            | --grid --cx --cy --acquired        |                      | detect changes for a chip       |
+| lcmap train                  | --grid --tile                      |                      | train a model for a tile        |
+| lcmap predict                | --grid --tile                      |                      | predict a tile                  |
+| lcmap product                | --grid --tile --product --years    |                      | generate json products for tile |
+| lcmap product-chip           | --grid --product --years --cx --cy |                      | generate json product for chip  |
+| lcmap raster                 | --grid --tile --product --years    |                      | generate tile size map tiff     |
 
 ### Parameters
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lcmap-cli "0.1.4"
+(defproject lcmap-cli "0.2.4-SNAPSHOT"
   :description "LCMAP Devops Interface"
   :url "https://github.com/usgs-eros/lcmap-cli"
   :license {:name "Unlicense"

--- a/src/lcmap_cli/core.clj
+++ b/src/lcmap_cli/core.clj
@@ -32,34 +32,36 @@
   (into [] (options opts)))
 
 (def registry
-  {:grids       {:func #'lcmap-cli.functions/grids
-                 :args (->options [:help])}                 
-   :grid        {:func #'lcmap-cli.functions/grid
-                 :args (->options [:help :grid :dataset])}
-   :snap        {:func #'lcmap-cli.functions/snap
-                 :args (->options [:help :grid :dataset :x :y])}
-   :near        {:func #'lcmap-cli.functions/near
-                 :args (->options [:help :grid :dataset :x :y])}
-   :xy-to-tile  {:func #'lcmap-cli.functions/xy-to-tile
-                 :args (->options [:help :grid :dataset :x :y])}
-   :tile-to-xy  {:func #'lcmap-cli.functions/tile-to-xy
-                 :args (->options [:help :grid :dataset :tile])}
-   :chips       {:func #'lcmap-cli.functions/chips
-                 :args (->options [:help :grid :dataset :tile])}
-   :ingest      {:func nil
-                 :args (->options [:help :grid :source])}
-   :detect-chip {:func #'lcmap-cli.changedetection/chip
-                 :args (->options [:help :grid :cx :cy :acquired])}
-   :detect      {:func #'lcmap-cli.changedetection/tile
-                 :args (->options [:help :grid :tile :acquired])}
-   :train       {:func nil
-                 :args (->options [:help :grid :tile])}
-   :predict     {:func nil
-                 :args (->options [:help :grid :tile])}
-   :product     {:func #'lcmap-cli.products/product 
-                 :args (->options [:help :grid :tile :product :years])}
-   :raster      {:func #'lcmap-cli.products/raster 
-                 :args (->options [:help :grid :tile :product :years])}
+  {:grids        {:func #'lcmap-cli.functions/grids
+                  :args (->options [:help])}                 
+   :grid         {:func #'lcmap-cli.functions/grid
+                  :args (->options [:help :grid :dataset])}
+   :snap         {:func #'lcmap-cli.functions/snap
+                  :args (->options [:help :grid :dataset :x :y])}
+   :near         {:func #'lcmap-cli.functions/near
+                  :args (->options [:help :grid :dataset :x :y])}
+   :xy-to-tile   {:func #'lcmap-cli.functions/xy-to-tile
+                  :args (->options [:help :grid :dataset :x :y])}
+   :tile-to-xy   {:func #'lcmap-cli.functions/tile-to-xy
+                  :args (->options [:help :grid :dataset :tile])}
+   :chips        {:func #'lcmap-cli.functions/chips
+                  :args (->options [:help :grid :dataset :tile])}
+   :ingest       {:func nil
+                  :args (->options [:help :grid :source])}
+   :detect-chip  {:func #'lcmap-cli.changedetection/chip
+                  :args (->options [:help :grid :cx :cy :acquired])}
+   :detect       {:func #'lcmap-cli.changedetection/tile
+                  :args (->options [:help :grid :tile :acquired])}
+   :train        {:func nil
+                  :args (->options [:help :grid :tile])}
+   :predict      {:func nil
+                  :args (->options [:help :grid :tile])}
+   :product      {:func #'lcmap-cli.products/product 
+                  :args (->options [:help :grid :tile :product :years])}
+   :product-chip {:func #'lcmap-cli.products/chip 
+                  :args (->options [:help :grid :product :tile :cx :cy :years])}
+   :raster       {:func #'lcmap-cli.products/raster 
+                  :args (->options [:help :grid :tile :product :years])}
 })
 
 (defn usage [action options-summary]

--- a/src/lcmap_cli/products.clj
+++ b/src/lcmap_cli/products.clj
@@ -51,8 +51,9 @@
     (map (fn [i] (str i "-" mmdd)) year_range)))
 
 (defn chip
-  [{grid :grid tile :tile product :product years :years cx :cx cy :cy :as all}]
-  (let [date-coll (date-range all)
+  [{grid :grid product :product years :years cx :cx cy :cy :as all}]
+  (let [tile      (f/xy-to-tile {:grid grid :dataset "ard" :x cx :y cy}) 
+        date-coll (date-range all)
         req-args  (-> (dissoc all :years) (assoc :dates date-coll :resource "product" :http-options cfg/http-options)) 
         response  (post-request req-args)
         output    (handler response)]

--- a/src/lcmap_cli/products.clj
+++ b/src/lcmap_cli/products.clj
@@ -50,6 +50,15 @@
         mmdd (cfg/product-mmdd grid)]
     (map (fn [i] (str i "-" mmdd)) year_range)))
 
+(defn chip
+  [{grid :grid tile :tile product :product years :years cx :cx cy :cy :as all}]
+  (let [date-coll (date-range all)
+        req-args  (-> (dissoc all :years) (assoc :dates date-coll :resource "product" :http-options cfg/http-options)) 
+        response  (post-request req-args)
+        output    (handler response)]
+    (f/output output)
+    output))
+
 (defn product
   [{grid :grid tile :tile product :product years :years :as all}]
   (let [chunk-size (cfg/product-instance-count grid)

--- a/test/lcmap_cli/products_test.clj
+++ b/test/lcmap_cli/products_test.clj
@@ -56,10 +56,11 @@
 (deftest chip-test
   (with-redefs [products/handler      str
                 products/post-request keys
-                cfg/http-options      {:timeout 9}]
+                cfg/http-options      {:timeout 9}
+                functions/xy-to-tile  (fn [i] "027008")]
 
-    (is (= "(:grid :tile :cx :cy :product :dates :resource :http-options)"
-           (products/chip {:grid "conus" :tile "027008" :cx 111111 :cy 222222 :product "tsc" :years "2006"})))))
+    (is (= "(:grid :cx :cy :product :dates :resource :http-options)"
+           (products/chip {:grid "conus" :cx 111111 :cy 222222 :product "tsc" :years "2006"})))))
 
 (deftest product-test
   (with-redefs [cfg/product-instance-count (fn [i] 1)

--- a/test/lcmap_cli/products_test.clj
+++ b/test/lcmap_cli/products_test.clj
@@ -53,8 +53,15 @@
 (deftest date-range-test
     (is (= ["2006-07-01" "2007-07-01"] (products/date-range {:grid "fake-http" :years "2006/2007"}))))
 
+(deftest chip-test
+  (with-redefs [products/handler      str
+                products/post-request keys
+                cfg/http-options      {:timeout 9}]
 
-(deftest products-test
+    (is (= "(:grid :tile :cx :cy :product :dates :resource :http-options)"
+           (products/chip {:grid "conus" :tile "027008" :cx 111111 :cy 222222 :product "tsc" :years "2006"})))))
+
+(deftest product-test
   (with-redefs [cfg/product-instance-count (fn [i] 1)
                 functions/chips       (fn [i] [{:cx 1 :cy 2}])
                 functions/tile-to-xy  (fn [i] {:x 3 :y 4})
@@ -65,7 +72,7 @@
     (is (= '("(:tile :dates :grid :product :cx :resource :cy :http-options)")
        (products/product {:grid "conus" :tile "027008" :product "tsc" :years "2006"})))))
 
-(deftest maps-test
+(deftest raster-test
   (with-redefs [cfg/raster-instance-count (fn [i] 1)
                 functions/chips       (fn [i] [{:cx 1 :cy 2}])
                 functions/tile-to-xy  (fn [i] {:x 3 :y 4})


### PR DESCRIPTION
mirroring detect-chip behavior. letting users run a single chip at a time, in instances where a few chips during batch runs on an entire tile fail. 